### PR TITLE
refactor to simplify the user experience

### DIFF
--- a/src/functional_base_charm/charm_reconciler.py
+++ b/src/functional_base_charm/charm_reconciler.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 """A reusable reconcile loop for Charms."""
 import logging
-from typing import Optional, List
+from typing import List, Optional
 
 from ops import CharmBase, EventBase, Object, StatusBase
 
@@ -110,7 +110,9 @@ class CharmReconciler(Object):
                 component_item.component.remove(event)
                 logger.info(f"Successfully removed component {component_item.name}")
             except Exception as err:
-                logger.warning(f"Failed to remove component {component_item.name} - caught error {err}")
+                logger.warning(
+                    f"Failed to remove component {component_item.name} - caught error {err}"
+                )
 
     def status(self) -> StatusBase:
         """Returns a status representing the the entire charm execution.

--- a/src/functional_base_charm/charm_reconciler.py
+++ b/src/functional_base_charm/charm_reconciler.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 """A reusable reconcile loop for Charms."""
 import logging
+from typing import Optional, List
 
 from ops import CharmBase, EventBase, Object, StatusBase
 
@@ -13,8 +14,22 @@ logger = logging.getLogger(__name__)
 class CharmReconciler(Object):
     """A reusable reconcile loop for Charms."""
 
-    def __init__(self, charm: CharmBase, component_graph: ComponentGraph):
+    def __init__(self, charm: CharmBase, component_graph: Optional[ComponentGraph] = None):
+        """A reusable reconcile loop for Charms.
+
+        TODO: Do we really need to pass `charm` here?  We barely use it.  I think we need it (or
+         really, the framework) to
+
+        Args:
+            charm: a CharmBase object to operate from this CharmReconciler
+            component_graph: (optional) a ComponentGraph that is used to define the execution order
+                             of Components.  If None, an empty ComponentGraph will be created.
+        """
         super().__init__(parent=charm, key=None)
+
+        if component_graph is None:
+            component_graph = ComponentGraph()
+
         self._charm = charm
         self.component_graph = component_graph
 

--- a/src/functional_base_charm/component.py
+++ b/src/functional_base_charm/component.py
@@ -60,6 +60,10 @@ class Component(Object, ABC):
         """
         return True
 
+    def remove(self, event):
+        """Removes everything this Component should when handling a `remove` event."""
+        pass
+
     @property
     def events_to_observe(self) -> List[BoundEvent]:
         """Returns the list of events this Component wants to observe."""

--- a/src/functional_base_charm/component.py
+++ b/src/functional_base_charm/component.py
@@ -83,7 +83,8 @@ class Component(Object, ABC):
     def _configure_unit(self, event):
         """Executes everything this Component should do for every Unit.
 
-        Can be overridden to implement anything this Component should do for every unit in the charm.
+        Can be overridden to implement anything this Component should do for every unit in the
+        charm.
         """
         pass
 

--- a/src/functional_base_charm/component.py
+++ b/src/functional_base_charm/component.py
@@ -35,8 +35,11 @@ class Component(Object, ABC):
     def configure_charm(self, event):
         """Public API to get this Component to do whatever it should with an Event.
 
-        Generally should be reusable for most use cases.  Ideally, the _private
-        methods are where subclasses should modify behaviour.
+        Generally, this should not need modification.  Instead, implement the Component's logic in
+        one or more of:
+        * _configure_unit: for work executed on every unit in an application
+        * _configure_app_leader: for work executed on only the leader of an application
+        * _configure_app_non_leader: for work executed on only the non-leaders of an application
         """
         self._configure_unit(event)
         self._configure_app(event)
@@ -51,51 +54,53 @@ class Component(Object, ABC):
         """Returns boolean indicating if Component is ready for execution.
 
         Extend this method with custom logic if this Component has validation to run before it can
-        be executed.  For example, a PebbleContainer can check weather the container is ready.
+        be executed.  For example:
+        * a PebbleContainer can check whether the container is ready
+        * a Component that requires leadership can check self._charm.unit.is_leader()
         """
         return True
 
     @property
     def events_to_observe(self) -> List[BoundEvent]:
-        """Returns the list of events this Component wants to observe.
-
-        TODO: Would this be better returning actual BoundEvents instead of their names?
-        """
+        """Returns the list of events this Component wants to observe."""
         return self._events_to_observe
 
     def _configure_app(self, event):
         """Execute everything this Component should do at the Application level.
 
-        Generally should be reusable for most use cases.  Ideally, override
-        _configure_app_leader and _configure_app_non_leader instead.
+        Generally, this should not need modification.  Instead, implement the Component's logic in
+        one or more of:
+        * _configure_unit: for work executed on every unit in an application
+        * _configure_app_leader: for work executed on only the leader of an application
+        * _configure_app_non_leader: for work executed on only the non-leaders of an application
         """
-        self._configure_app_leader(event)
-        self._configure_app_non_leader(event)
+        if self._charm.unit.is_leader():
+            self._configure_app_leader(event)
+        else:
+            self._configure_app_non_leader(event)
 
     # Methods that should be overridden when creating a Component subclass
-    @abstractmethod
     def _configure_unit(self, event):
         """Executes everything this Component should do for every Unit.
 
-        Override this method to implement anything this Component should do for
-        every unit in the charm.
+        Can be overridden to implement anything this Component should do for every unit in the charm.
         """
+        pass
 
-    @abstractmethod
     def _configure_app_leader(self, event):
         """Execute everything this Component should do at the Application level for leaders.
 
-        Override this method to implement anything this Component should do for
-        the leader unit.
+        Can be overridden to implement anything this Component should do for the leader unit.
         """
+        pass
 
-    @abstractmethod
     def _configure_app_non_leader(self, event):
         """Execute everything this Component should do at the Application level for non-Leaders.
 
-        Override this method to implement anything this Component should do for
-        every unit that is not the leader.
+        Can be overridden to implement anything this Component should do for every unit that is
+        not the leader.
         """
+        pass
 
     @property
     @abstractmethod

--- a/src/functional_base_charm/component_graph.py
+++ b/src/functional_base_charm/component_graph.py
@@ -39,7 +39,7 @@ class ComponentGraph:
         #  or is this not needed?  If everything knows its dependencies and only says it is ready
         #  if they're satisfied, that might be enough.
         self.component_items[name] = ComponentGraphItem(
-            component=component, name=name, depends_on=depends_on
+            component=component, depends_on=depends_on
         )
 
         self.status_prioritiser.add(name, lambda: self.component_items[name].status)

--- a/src/functional_base_charm/component_graph.py
+++ b/src/functional_base_charm/component_graph.py
@@ -25,12 +25,18 @@ class ComponentGraph:
     def add(
         self,
         component: Component,
-        name: str,
         depends_on: Optional[List[ComponentGraphItem]] = None,
     ) -> ComponentGraphItem:
-        """Add a component to the graph, returning a ComponentGraphItem for this Component."""
+        """Add a component to the graph, returning a ComponentGraphItem for this Component.
+
+        Args:
+            component: the Component to add to this execution graph
+            depends_on: the list of registered ComponentGraphItems that this Component depends on
+                        being Active before it should run.
+        """
         # TODO: It feels easier to pass Component's in `depends_on`, but then harder for us to
         #  process them here (we identify components by their name).
+        name = component.name
         if name in self.component_items:
             raise ValueError(
                 f"Cannot add component {name} - component named {name} already exists."
@@ -38,9 +44,7 @@ class ComponentGraph:
         # TODO: Make an actual graph of this
         #  or is this not needed?  If everything knows its dependencies and only says it is ready
         #  if they're satisfied, that might be enough.
-        self.component_items[name] = ComponentGraphItem(
-            component=component, depends_on=depends_on
-        )
+        self.component_items[name] = ComponentGraphItem(component=component, depends_on=depends_on)
 
         self.status_prioritiser.add(name, lambda: self.component_items[name].status)
 

--- a/src/functional_base_charm/component_graph_item.py
+++ b/src/functional_base_charm/component_graph_item.py
@@ -19,11 +19,10 @@ class ComponentGraphItem:
     def __init__(
         self,
         component: Component,
-        name: str,
         depends_on: Optional[List[ComponentGraphItem]] = None,
     ):
         self.component = component
-        self.name = name
+        self.name = self.component.name
         self.depends_on = depends_on or []
         self._executed: bool = False
 

--- a/src/functional_base_charm/kubernetes_component.py
+++ b/src/functional_base_charm/kubernetes_component.py
@@ -89,6 +89,11 @@ class KubernetesComponent(Component):
         Todo: This could use improvements on validation, and some of the logic could be moved into
         the KubernetesResourceHandler class.
         """
+        if not self._charm.unit.is_leader():
+            # We have no work to do, so we are always active.
+            # Ideally, there would be a "no status" option.  Maybe Unknown?
+            return ActiveStatus()
+
         # TODO: Add better validation
         missing_resources = self._get_missing_kubernetes_resources()
 

--- a/src/functional_base_charm/kubernetes_component.py
+++ b/src/functional_base_charm/kubernetes_component.py
@@ -42,11 +42,6 @@ class KubernetesComponent(Component):
             context_callable = lambda: {}  # noqa: E731
         self._context_callable = context_callable
 
-    def _configure_unit(self, event):
-        """Executes everything this Component should do for every Unit."""
-        # no per-unit actions needed
-        pass
-
     def _configure_app_leader(self, event):
         """Execute everything this Component should do at the Application level for leaders."""
         try:
@@ -55,11 +50,6 @@ class KubernetesComponent(Component):
         except ApiError as e:
             # TODO: Blocked?
             raise GenericCharmRuntimeError("Failed to create Kubernetes resources") from e
-
-    def _configure_app_non_leader(self, event):
-        """Execute everything this Component should do at the Application level for non-Leaders."""
-        # no non-leader application actions needed
-        pass
 
     def _get_kubernetes_resource_handler(self) -> KubernetesResourceHandler:
         """Returns a KubernetesResourceHandler for this class."""

--- a/src/functional_base_charm/kubernetes_component.py
+++ b/src/functional_base_charm/kubernetes_component.py
@@ -60,7 +60,7 @@ class KubernetesComponent(Component):
             context=self._context_callable(),
             lightkube_client=self._lightkube_client,
             labels=self._krh_labels,
-            child_resource_types=self._krh_child_resource_types,
+            resource_types=self._krh_child_resource_types,
         )
         load_in_cluster_generic_resources(k8s_resource_handler.lightkube_client)
         return k8s_resource_handler
@@ -81,6 +81,11 @@ class KubernetesComponent(Component):
             desired_resources, existing_resources, hasher=_hash_lightkube_resource
         )
         return missing_resources
+
+    def remove(self, event):
+        """Removes all deployed resources."""
+        krh = self._get_kubernetes_resource_handler()
+        krh.delete()
 
     @property
     def status(self) -> StatusBase:

--- a/src/functional_base_charm/pebble_component.py
+++ b/src/functional_base_charm/pebble_component.py
@@ -81,15 +81,6 @@ class PebbleComponent(Component):
         """Execute the given command in the container managed by this Component."""
         raise NotImplementedError()
 
-    def _configure_unit(self, event):
-        pass
-
-    def _configure_app_leader(self, event):
-        pass
-
-    def _configure_app_non_leader(self, event):
-        pass
-
     def _push_files_to_container(self):
         """Renders and pushes the files defined in self._files_to_push into the container."""
         container = self._charm.unit.get_container(self.container_name)

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -100,7 +100,6 @@ def component_graph_item_factory(harness):
     def factory(harness=harness, name=COMPONENT_NAME) -> ComponentGraphItem:
         return ComponentGraphItem(
             component=MinimallyExtendedComponent(charm=harness.charm, name=name),
-            name=name,
         )
 
     return factory
@@ -113,7 +112,6 @@ def component_graph_item_active_factory(component_active_factory, harness):
     def factory(harness=harness, name=COMPONENT_NAME) -> ComponentGraphItem:
         cgi = ComponentGraphItem(
             component=component_active_factory(harness=harness, name=name),
-            name=name,
         )
         cgi.executed = True
         return cgi
@@ -128,7 +126,6 @@ def component_graph_item_with_depends_not_active_factory(component_graph_item_fa
     def factory(harness=harness, name=COMPONENT_NAME) -> ComponentGraphItem:
         return ComponentGraphItem(
             component=MinimallyExtendedComponent(charm=harness.charm, name=name),
-            name=name,
             depends_on=[component_graph_item_factory(harness=harness, name="dependency")],
         )
 
@@ -142,7 +139,6 @@ def component_graph_item_with_depends_active_factory(component_graph_item_active
     def factory(harness=harness, name=COMPONENT_NAME) -> ComponentGraphItem:
         return ComponentGraphItem(
             component=MinimallyExtendedComponent(charm=harness.charm, name=name),
-            name=name,
             depends_on=[component_graph_item_active_factory(harness=harness, name="dependency")],
         )
 

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -25,12 +25,6 @@ class MinimallyExtendedComponent(Component):
         # Mock placeholder for state that indicates this Component's work is complete
         self._completed_work = None
 
-    def _configure_app_leader(self, event):
-        pass
-
-    def _configure_app_non_leader(self, event):
-        pass
-
     @property
     def status(self) -> StatusBase:
         """Returns ActiveStatus if self._completed_work is not Falsey, else WaitingStatus."""
@@ -81,7 +75,7 @@ def component_active_factory():
     """Returns a factory for Components that will be Active."""
 
     def factory(harness=harness, name=COMPONENT_NAME) -> Component:
-        component = MinimallyExtendedComponent(charm=harness.framework, name=name)
+        component = MinimallyExtendedComponent(charm=harness.charm, name=name)
         # "execute" the Component, making it now be Active because work has been done
         component.configure_charm("mock event")
         return component
@@ -94,7 +88,7 @@ def component_inactive_factory(harness):
     """Returns a factory for Components that will not be Active."""
 
     def factory(harness=harness, name=COMPONENT_NAME) -> Component:
-        return MinimallyExtendedComponent(charm=harness.framework, name=name)
+        return MinimallyExtendedComponent(charm=harness.charm, name=name)
 
     return factory
 
@@ -105,7 +99,7 @@ def component_graph_item_factory(harness):
 
     def factory(harness=harness, name=COMPONENT_NAME) -> ComponentGraphItem:
         return ComponentGraphItem(
-            component=MinimallyExtendedComponent(charm=harness.framework, name=name),
+            component=MinimallyExtendedComponent(charm=harness.charm, name=name),
             name=name,
         )
 
@@ -133,7 +127,7 @@ def component_graph_item_with_depends_not_active_factory(component_graph_item_fa
 
     def factory(harness=harness, name=COMPONENT_NAME) -> ComponentGraphItem:
         return ComponentGraphItem(
-            component=MinimallyExtendedComponent(charm=harness.framework, name=name),
+            component=MinimallyExtendedComponent(charm=harness.charm, name=name),
             name=name,
             depends_on=[component_graph_item_factory(harness=harness, name="dependency")],
         )
@@ -147,7 +141,7 @@ def component_graph_item_with_depends_active_factory(component_graph_item_active
 
     def factory(harness=harness, name=COMPONENT_NAME) -> ComponentGraphItem:
         return ComponentGraphItem(
-            component=MinimallyExtendedComponent(charm=harness.framework, name=name),
+            component=MinimallyExtendedComponent(charm=harness.charm, name=name),
             name=name,
             depends_on=[component_graph_item_active_factory(harness=harness, name="dependency")],
         )

--- a/tests/unit/test_charm_reconciler.py
+++ b/tests/unit/test_charm_reconciler.py
@@ -1,0 +1,55 @@
+from functional_base_charm.charm_reconciler import CharmReconciler
+from functional_base_charm.component_graph import ComponentGraph
+from fixtures import (  # noqa: F401
+    MinimallyExtendedComponent,
+    harness,
+)
+
+# TODO: Add tests for execute_components, install
+
+
+class TestBasicFunction:
+    def test_init_with_component_graph(self, harness):
+        """Test that initialising a CharmReconciler with a ComponentGraph works as expected."""
+        # Arrange
+        charm = harness.charm
+
+        component_graph = ComponentGraph()
+        component_graph.add(MinimallyExtendedComponent(charm=charm, name="component"))
+
+        # Act
+        charm_reconciler = CharmReconciler(charm, component_graph)
+
+        # Assert
+        assert charm_reconciler._component_graph == component_graph
+
+    def test_init_without_component_graph(self, harness):
+        """Test that initialising a CharmReconciler without a ComponentGraph works as expected."""
+        # Arrange
+        charm = harness.charm
+
+        # Act
+        charm_reconciler = CharmReconciler(charm)
+
+        # Assert that we have a new ComponentGraph automatically created
+        assert isinstance(charm_reconciler._component_graph, ComponentGraph)
+
+    def test_add_component(self, harness):
+        """Test that adding Components to a CharmReconciler works as expected."""
+        # Arrange
+        charm = harness.charm
+
+        charm_reconciler = CharmReconciler(charm)
+
+        component1 = MinimallyExtendedComponent(charm=charm, name="component1")
+        component2 = MinimallyExtendedComponent(charm=charm, name="component2")
+
+        # Act
+        component_graph_item1 = charm_reconciler.add(component1)
+        component_graph_item2 = charm_reconciler.add(component2, depends_on=[component_graph_item1])
+
+        # Assert
+        assert component_graph_item2.depends_on[0] == component_graph_item1
+        assert component_graph_item1.name in charm_reconciler._component_graph.component_items
+        assert component_graph_item2.name in charm_reconciler._component_graph.component_items
+        assert len(charm_reconciler._component_graph.component_items) == 2

--- a/tests/unit/test_charm_reconciler.py
+++ b/tests/unit/test_charm_reconciler.py
@@ -5,7 +5,7 @@ from fixtures import (  # noqa: F401
     harness,
 )
 
-# TODO: Add tests for execute_components, install
+# TODO: Add tests for execute_components, install, remove_components
 
 
 class TestBasicFunction:

--- a/tests/unit/test_charm_reconciler.py
+++ b/tests/unit/test_charm_reconciler.py
@@ -1,15 +1,16 @@
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+from fixtures import MinimallyExtendedComponent, harness  # noqa: F401
+
 from functional_base_charm.charm_reconciler import CharmReconciler
 from functional_base_charm.component_graph import ComponentGraph
-from fixtures import (  # noqa: F401
-    MinimallyExtendedComponent,
-    harness,
-)
 
 # TODO: Add tests for execute_components, install, remove_components
 
 
 class TestBasicFunction:
-    def test_init_with_component_graph(self, harness):
+    def test_init_with_component_graph(self, harness):  # noqa: F811
         """Test that initialising a CharmReconciler with a ComponentGraph works as expected."""
         # Arrange
         charm = harness.charm
@@ -23,7 +24,7 @@ class TestBasicFunction:
         # Assert
         assert charm_reconciler._component_graph == component_graph
 
-    def test_init_without_component_graph(self, harness):
+    def test_init_without_component_graph(self, harness):  # noqa: F811
         """Test that initialising a CharmReconciler without a ComponentGraph works as expected."""
         # Arrange
         charm = harness.charm
@@ -34,7 +35,7 @@ class TestBasicFunction:
         # Assert that we have a new ComponentGraph automatically created
         assert isinstance(charm_reconciler._component_graph, ComponentGraph)
 
-    def test_add_component(self, harness):
+    def test_add_component(self, harness):  # noqa: F811
         """Test that adding Components to a CharmReconciler works as expected."""
         # Arrange
         charm = harness.charm
@@ -46,7 +47,9 @@ class TestBasicFunction:
 
         # Act
         component_graph_item1 = charm_reconciler.add(component1)
-        component_graph_item2 = charm_reconciler.add(component2, depends_on=[component_graph_item1])
+        component_graph_item2 = charm_reconciler.add(
+            component2, depends_on=[component_graph_item1]
+        )
 
         # Assert
         assert component_graph_item2.depends_on[0] == component_graph_item1

--- a/tests/unit/test_component.py
+++ b/tests/unit/test_component.py
@@ -11,33 +11,60 @@ from ops import ActiveStatus, WaitingStatus
 class TestMinimallyExtendedComponent:
     def test_status_before_execution(self, harness):  # noqa: F811
         """Tests that the minimal implementation of Component does not raise a syntax error."""
-        component = MinimallyExtendedComponent(charm=harness.framework, name="test-component")
+        component = MinimallyExtendedComponent(charm=harness.charm, name="test-component")
         assert isinstance(component.status, WaitingStatus)
 
     def test_status_after_execution(self, harness):  # noqa: F811
         """Tests that the minimal implementation of Component does not raise a syntax error."""
-        component = MinimallyExtendedComponent(charm=harness.framework, name="test-component")
+        component = MinimallyExtendedComponent(charm=harness.charm, name="test-component")
         component.configure_charm("mock event")
         assert isinstance(component.status, ActiveStatus)
 
-    def test_configure_charm(self, harness):  # noqa: F811
-        component = MinimallyExtendedComponent(charm=harness.framework, name="test-component")
+    def test_configure_charm_as_leader(self, harness):  # noqa: F811
+        harness.set_leader(True)
+        component = MinimallyExtendedComponent(charm=harness.charm, name="test-component")
 
-        with (
-            patch.object(
-                component, "_configure_app_leader", wraps=component._configure_app_leader
-            ) as spied_configure_app_leader,
-            patch.object(
-                component, "_configure_app_non_leader", wraps=component._configure_app_non_leader
-            ) as spied_configure_app_non_leader,
-            patch.object(
-                component, "_configure_unit", wraps=component._configure_unit
-            ) as spied_configure_unit,
-        ):
-            # TODO: Make a real event somehow
-            event = "TODO: make this a real event"
-            component.configure_charm(event)
+        results = configure_charm_and_spy(component)
+        assert results["configure_app_leader"] is True
+        assert results["configure_app_non_leader"] is False
+        assert results["configure_unit"] is True
 
-            spied_configure_app_leader.assert_called()
-            spied_configure_app_non_leader.assert_called()
-            spied_configure_unit.assert_called()
+    def test_configure_charm_as_non_leader(self, harness):  # noqa: F811
+        harness.set_leader(False)
+        component = MinimallyExtendedComponent(charm=harness.charm, name="test-component")
+
+        results = configure_charm_and_spy(component)
+        assert results["configure_app_leader"] is False
+        assert results["configure_app_non_leader"] is True
+        assert results["configure_unit"] is True
+
+
+def configure_charm_and_spy(component):
+    """Executes component.configure_charm() and returns whether _configure* methods were called.
+
+    Returns:
+        Dict of:
+            configure_app_leader: Boolean of whether this method was called
+            configure_app_non_leader: Boolean of whether this method was called
+            configure_unit: Boolean of whether this method was called
+    """
+    with (
+        patch.object(
+            component, "_configure_app_leader", wraps=component._configure_app_leader
+        ) as spied_configure_app_leader,
+        patch.object(
+            component, "_configure_app_non_leader", wraps=component._configure_app_non_leader
+        ) as spied_configure_app_non_leader,
+        patch.object(
+            component, "_configure_unit", wraps=component._configure_unit
+        ) as spied_configure_unit,
+    ):
+        # TODO: Make a real event somehow
+        event = "TODO: make this a real event"
+        component.configure_charm(event)
+        results = {
+            "configure_app_leader": spied_configure_app_leader.called,
+            "configure_app_non_leader": spied_configure_app_non_leader.called,
+            "configure_unit": spied_configure_unit.called,
+        }
+        return results

--- a/tests/unit/test_component.py
+++ b/tests/unit/test_component.py
@@ -1,7 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-# TODO.  Just storing some stuff here for now
 from unittest.mock import patch
 
 from fixtures import MinimallyExtendedComponent, harness  # noqa F401

--- a/tests/unit/test_component_graph.py
+++ b/tests/unit/test_component_graph.py
@@ -20,7 +20,6 @@ class TestAdd:
         name = "component1"
         cgi1 = cg.add(
             component=MinimallyExtendedComponent(charm=harness, name=name),
-            name=name,
             depends_on=[],
         )
 
@@ -29,14 +28,12 @@ class TestAdd:
         name = "component2"
         cgi2 = cg.add(
             component=MinimallyExtendedComponent(charm=harness, name=name),
-            name=name,
             depends_on=[cgi1],
         )
 
         name = "component3"
         cgi3 = cg.add(
             component=MinimallyExtendedComponent(charm=harness, name=name),
-            name=name,
             depends_on=[cgi1, cgi2],
         )
 
@@ -45,12 +42,17 @@ class TestAdd:
 
     def test_add_existing_item_raises(self, harness):  # noqa: F811
         """Tests that adding two Components of the same name raises an Exception."""
-        name = "component"
+
+        class MockComponent:
+            # Use a mocked Component rather than a real Component because you cannot register two
+            # framework Objects of the same name to the same framework.  If we try to create two
+            # Components here of the same name, we will get a RuntimeError from the harness.
+            name = "component"
 
         cg = ComponentGraph()
-        cg.add(component=MinimallyExtendedComponent(harness, name), name=name)
+        cg.add(component=MockComponent())
         with pytest.raises(ValueError):
-            cg.add(component=MinimallyExtendedComponent(harness, name + "1"), name=name)
+            cg.add(component=MockComponent())
 
 
 class TestGetExecutableComponentItems:
@@ -63,15 +65,13 @@ class TestGetExecutableComponentItems:
     ):
         cg = ComponentGraph()
         name = "component1"
-        cgi1 = cg.add(
-            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[]
-        )
+        cgi1 = cg.add(component=MinimallyExtendedComponent(harness.charm, name), depends_on=[])
 
         name = "component2"
-        cg.add(component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1])
+        cg.add(component=MinimallyExtendedComponent(harness.charm, name), depends_on=[cgi1])
 
         name = "component3"
-        cg.add(component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1])
+        cg.add(component=MinimallyExtendedComponent(harness.charm, name), depends_on=[cgi1])
 
         # Assert that we have one cgi ready for execution (cgi1)
         executable_cgis = cg.get_executable_component_items()
@@ -99,7 +99,6 @@ class TestStatus:
         name = "cgi-active"
         cgi_active = cg.add(
             component=MinimallyExtendedComponent(harness.charm, name),
-            name=name,
         )
         # "execute" it to make it active
         cgi_active.executed = True
@@ -109,7 +108,6 @@ class TestStatus:
         name = "cgi-blocked"
         cgi_blocked = cg.add(
             component=MinimallyBlockedComponent(harness.charm, name),
-            name=name,
         )
         cgi_blocked.executed = True
 
@@ -117,7 +115,6 @@ class TestStatus:
         name = "cgi-waiting"
         cgi_waiting = cg.add(
             component=MinimallyExtendedComponent(harness.charm, name),
-            name=name,
         )
         cgi_waiting.executed = True
 
@@ -135,9 +132,7 @@ class TestYieldExecutableComponentItems:
         """Tests that the generator does not yield anything if there is nothing executable."""
         cg = ComponentGraph()
         name = "component1"
-        cgi1 = cg.add(
-            component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[]
-        )
+        cgi1 = cg.add(component=MinimallyExtendedComponent(harness, name), depends_on=[])
         cgi1.executed = True
 
         with pytest.raises(StopIteration):
@@ -147,23 +142,17 @@ class TestYieldExecutableComponentItems:
         """An end-to-end style test of ComponentGraph.yield_executable_component_items()."""
         cg = ComponentGraph()
         name = "component1"
-        cgi1 = cg.add(
-            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[]
-        )
+        cgi1 = cg.add(component=MinimallyExtendedComponent(harness.charm, name), depends_on=[])
 
         name = "component2"
-        cgi2 = cg.add(
-            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1]
-        )
+        cgi2 = cg.add(component=MinimallyExtendedComponent(harness.charm, name), depends_on=[cgi1])
 
         name = "component3"
-        cgi3 = cg.add(
-            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1]
-        )
+        cgi3 = cg.add(component=MinimallyExtendedComponent(harness.charm, name), depends_on=[cgi1])
 
         name = "component4"
         cgi4 = cg.add(
-            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi2, cgi3]
+            component=MinimallyExtendedComponent(harness.charm, name), depends_on=[cgi2, cgi3]
         )
 
         cgi_generator = cg.yield_executable_component_items()
@@ -212,12 +201,12 @@ class TestEventsToObserve:
         component1 = MinimallyExtendedComponent(harness, "test1")
         events1 = ["event1", "event1b"]
         component1._events_to_observe = events1
-        cg.add(component=component1, name=component1.name)
+        cg.add(component=component1)
 
         component2 = MinimallyExtendedComponent(harness, "test2")
         events2 = ["event2"]
         component2._events_to_observe = events2
-        cg.add(component=component2, name=component2.name)
+        cg.add(component=component2)
 
         expected_events = events1 + events2
         assert cg.get_events_to_observe() == expected_events

--- a/tests/unit/test_component_graph.py
+++ b/tests/unit/test_component_graph.py
@@ -64,14 +64,14 @@ class TestGetExecutableComponentItems:
         cg = ComponentGraph()
         name = "component1"
         cgi1 = cg.add(
-            component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[]
+            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[]
         )
 
         name = "component2"
-        cg.add(component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[cgi1])
+        cg.add(component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1])
 
         name = "component3"
-        cg.add(component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[cgi1])
+        cg.add(component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1])
 
         # Assert that we have one cgi ready for execution (cgi1)
         executable_cgis = cg.get_executable_component_items()
@@ -98,7 +98,7 @@ class TestStatus:
         # Add a Component that is Active
         name = "cgi-active"
         cgi_active = cg.add(
-            component=MinimallyExtendedComponent(harness, name),
+            component=MinimallyExtendedComponent(harness.charm, name),
             name=name,
         )
         # "execute" it to make it active
@@ -108,7 +108,7 @@ class TestStatus:
         # Add a Component that is Blocked
         name = "cgi-blocked"
         cgi_blocked = cg.add(
-            component=MinimallyBlockedComponent(harness, name),
+            component=MinimallyBlockedComponent(harness.charm, name),
             name=name,
         )
         cgi_blocked.executed = True
@@ -116,7 +116,7 @@ class TestStatus:
         # Add a Component that is Waiting
         name = "cgi-waiting"
         cgi_waiting = cg.add(
-            component=MinimallyExtendedComponent(harness, name),
+            component=MinimallyExtendedComponent(harness.charm, name),
             name=name,
         )
         cgi_waiting.executed = True
@@ -148,22 +148,22 @@ class TestYieldExecutableComponentItems:
         cg = ComponentGraph()
         name = "component1"
         cgi1 = cg.add(
-            component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[]
+            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[]
         )
 
         name = "component2"
         cgi2 = cg.add(
-            component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[cgi1]
+            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1]
         )
 
         name = "component3"
         cgi3 = cg.add(
-            component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[cgi1]
+            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi1]
         )
 
         name = "component4"
         cgi4 = cg.add(
-            component=MinimallyExtendedComponent(harness, name), name=name, depends_on=[cgi2, cgi3]
+            component=MinimallyExtendedComponent(harness.charm, name), name=name, depends_on=[cgi2, cgi3]
         )
 
         cgi_generator = cg.yield_executable_component_items()

--- a/tests/unit/test_component_graph_item.py
+++ b/tests/unit/test_component_graph_item.py
@@ -135,7 +135,6 @@ class TestInactivePrerequisites:
         """Tests inactive_prerequisites when CGI depends_on Active and not Active Components."""
         cgi = ComponentGraphItem(
             component=component_inactive_factory(),
-            name=COMPONENT_NAME,
             depends_on=[
                 component_graph_item_active_factory(name="dependency1"),
                 component_graph_item_factory(name="dependency2"),


### PR DESCRIPTION
This PR:
* removes @AbstractMethod from some Component methods, removing the need to implement boilerplate `pass` functions
* consolidates the `name` parameters so `Component.name` is used directly as the `name` in higher level objects rather than manually specified
* adds a `remove()` method to `Component` and remove handler to `CharmReconciler`